### PR TITLE
Update language-lc3.cson (hex a-f still not showing up as numbers)

### DIFF
--- a/grammars/language-lc3.cson
+++ b/grammars/language-lc3.cson
@@ -30,7 +30,7 @@
     'comment': 'Binary numbers format b10'
   }
   {
-    'match': '#?[0-9]+\\s'
+    'match': '#?-?[0-9]+\\s'
     'name': 'constant.numeric.dec'
     'comment': 'Decimal numbers format #123 123'
   }


### PR DESCRIPTION
#1 still not resolved, apparently markup.italic takes precedence over constant.numeric.hex

However, I have included negative numbers in the grammar now.

Also, the Atom package manager is confused about whether to get 4.0.0. It prompts every time and fails every time.

Really, you should just turn on issues.